### PR TITLE
Replace reusable_buffer with shared_ptr having stored deleter

### DIFF
--- a/library.hpp
+++ b/library.hpp
@@ -31,9 +31,10 @@ auto library<T>::fill() -> buffer_ptr<T> {
     #ifndef NDEBUG
         // check there was no changes after free
         T* f = new T();
-        memset(f, 0xf0, sizeof(T));
+        memset(reinterpret_cast<void*>(f), 0xf0, sizeof(T));
         assert(memcmp(ptr, f, sizeof(T)) == 0);
-        memset(ptr, 0, sizeof(T)*this->size);
+        memset(reinterpret_cast<void*>(ptr), 0, sizeof(T)*this->size);
+        delete f;
     #endif
 
     // make reuseable_buffer for the buffer
@@ -49,7 +50,6 @@ void library<T>::queue(buffer_ptr<T> ptr) {
         assert(this->pointers.find(ptr.get()) != this->pointers.end());
     #endif
     change_q.push_back(ptr);
-    guard.unlock();
     change_variable.notify_one();
 }
 
@@ -63,7 +63,6 @@ auto library<T>::operate() -> buffer_ptr<T> {
 
     buffer_ptr<T> r = change_q.front();
     change_q.pop_front();
-    change_mutex.unlock();
 
     return r;
 }

--- a/testing/test_class.hpp
+++ b/testing/test_class.hpp
@@ -131,18 +131,21 @@ struct unit_test {
         static void thread_wait_fill(
             std::shared_ptr<library<T>> recycler,
             std::shared_ptr<std::condition_variable> cv,
+            std::shared_ptr<std::mutex> m,
             bool &waiting_unsafe
         );
         template <typename T>
         static void thread_wait_queue(
             std::shared_ptr<library<T>> recycler,
             std::shared_ptr<std::condition_variable> cv,
+            std::shared_ptr<std::mutex> m,
             bool &waiting_unsafe
         );
         template <typename T>
         static void thread_watcher(
             buffer_ptr<T> p,
             std::shared_ptr<std::condition_variable> cv,
+            std::shared_ptr<std::mutex> m,
             bool &operating_unsafe,
             int &check_ref
         );

--- a/testing/test_class.hpp
+++ b/testing/test_class.hpp
@@ -126,7 +126,7 @@ struct unit_test {
 
     private:
         template <typename T>
-        static void thread_read(buffer_ptr<T> b, T data);
+        static void thread_read(std::shared_ptr<std::mutex> m, buffer_ptr<T> b, T data);
         template <typename T>
         static void thread_wait_fill(
             std::shared_ptr<library<T>> recycler,

--- a/testing/test_class.hpp
+++ b/testing/test_class.hpp
@@ -75,7 +75,8 @@ struct unit_test {
 
     template <typename T>
     static void dec_operate_queue(
-        std::shared_ptr<library<T>> recycler
+        std::shared_ptr<library<T>> recycler,
+        int max
     );
 
     

--- a/testing/test_impl.hpp
+++ b/testing/test_impl.hpp
@@ -167,6 +167,7 @@ void unit_test::change_one_buffer(
     int max,
     T data
 ) {
+    assert(max > 1);
     // -> check new data cannot be accessed from another buffer
 
     auto b1 = recycler->fill();
@@ -195,6 +196,7 @@ void unit_test::multi_change_buffer(
     T data,
     T diff
 ) {
+    assert(max > 1);
     // -> check new data cannot be accessed from another buffer
 
     auto b1 = recycler->fill();
@@ -242,10 +244,9 @@ void unit_test::set_buffer_ptr_array (
         size *= *iter;
     }
 
-    // fill each index with its number
+    // fill each index with zero
     T i = 0;
-    // T one = 1;
-    for (size_t idx = 0; idx < size; idx++ /*, i+one*/) {
+    for (size_t idx = 0; idx < size; idx++) {
         buffer[idx] = i;
         UnexpectedEq(buffer[idx], i, "array value");
     }
@@ -279,8 +280,10 @@ void unit_test::queue_buffer_from_fill (
 
 template <typename T>
 void unit_test::dec_operate_queue(
-    std::shared_ptr<library<T>> recycler
+    std::shared_ptr<library<T>> recycler,
+    int max
 ) {
+    assert(max > 1);
     auto b1 = recycler->fill();
     auto b2 = recycler->fill();
     UnexpectedEq(recycler->private_queue_size(), 0, "queue size");
@@ -303,12 +306,12 @@ void unit_test::dec_operate_queue(
 
 template <typename T>
 void unit_test::thread_read(std::shared_ptr<std::mutex> mtx, buffer_ptr<T> b, T data) {
+    mtx->lock();
     EXPECT_GE(b.use_count(), 2) <<
         "Unexpected reference count. Expected at least 2 and got " +
         std::to_string(b.use_count());
 
     UnexpectedEq(*b, data, "value");
-    mtx->lock();
     mtx->unlock();
 }
 
@@ -551,6 +554,7 @@ void unit_test::wait_multi_take_from_fill_threaded(
     int max,
     T data
 ) {
+    assert(max > 1);
 // -> check that the last one waits
     bool waiting_unsafe = false;
     std::shared_ptr<std::condition_variable> cv = 

--- a/testing/test_suites/buffer_recycler_test.cpp
+++ b/testing/test_suites/buffer_recycler_test.cpp
@@ -12,9 +12,11 @@ class BufferRecyclerTest : public testing::Test {
     protected:
         void SetUp() override {
             max = 2;
+            small_max = 1;
             shape = std::vector<size_t>(1, 1);
             array_shape = std::vector<size_t>(2, 2);
             recycler = std::make_shared<library<T>>(shape, max);
+            small_recycler = std::make_shared<library<T>>(shape, small_max);
             array_recycler = std::make_shared<library<T>>(array_shape, max);
         }
 
@@ -22,9 +24,11 @@ class BufferRecyclerTest : public testing::Test {
 
     public:
         int max;
+        int small_max;
         std::vector<size_t> shape;
         std::vector<size_t> array_shape;
         std::shared_ptr<library<T>> recycler = nullptr;
+        std::shared_ptr<library<T>> small_recycler = nullptr;
         std::shared_ptr<library<T>> array_recycler = nullptr;
 };
 
@@ -77,7 +81,7 @@ TYPED_TEST(BufferRecyclerTest, ThreadMultiBufferChange) {
 }
 
 TYPED_TEST(BufferRecyclerTest, ThreadWaitsForFill) {
-    unit_test::wait_on_fill_threaded<TypeParam>(this->recycler, this->max, 5);
+    unit_test::wait_on_fill_threaded<TypeParam>(this->small_recycler, this->small_max, 5);
 }
 
 TYPED_TEST(BufferRecyclerTest, ThreadMultiWaitsForFill) {

--- a/testing/test_suites/debug_test.cpp
+++ b/testing/test_suites/debug_test.cpp
@@ -53,9 +53,9 @@ TYPED_TEST(DebugTest, MemoryCheckF0) {
     }
 
     TypeParam* f = new TypeParam();
-    memset(f, 0xf0, sizeof(TypeParam));
+    memset(reinterpret_cast<void*>(f), 0xf0, sizeof(TypeParam));
     EXPECT_EQ(*f, *raw_ptr);
-    free(f);
+    delete f;
 }
 
 TYPED_TEST(DebugTest, MemoryCheckUseAfterFreeAssert) {

--- a/testing/test_suites/library_test.cpp
+++ b/testing/test_suites/library_test.cpp
@@ -36,7 +36,7 @@ TYPED_TEST(LibraryTest, QueueBuffer) {
 }
 
 TYPED_TEST(LibraryTest, DecOperate) {
-    unit_test::dec_operate_queue<TypeParam>(this->recycler);
+    unit_test::dec_operate_queue<TypeParam>(this->recycler, this->max);
 }
 
 TYPED_TEST(LibraryTest, ThreadWaitsForQueue) {


### PR DESCRIPTION
Besides removing the `reusuable_buffer` class, this PR also fixes some issues found by building tests with gcc 11 using `-fsanitize=address` and `-fsanitize=thread` flags, and resolving the runtime issues that were raised by the tests.

Note that there is no equivalent of `reusable_buffer::shape` possible with the elimination of `reusable_buffer`; perhaps that feature could move to `buffer_ptr`, but this PR doesn't do that.

I know that nobody asked for this PR, so feel free to take it or leave it as you see fit.